### PR TITLE
feat(story-1.3): implement authentication

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,25 @@ Preferred communication style: Simple, everyday language.
 - `bun <file>` — not node/ts-node
 - Bun loads `.env` automatically — do not use dotenv
 
+## Frontend Conventions
+
+### API Calls — Custom Hooks
+
+Never call `apiFetch` directly inside a component. Always wrap it in a custom hook in `client/src/hooks/`.
+
+- Hook owns the `apiFetch` call, `error` state, and `isPending` state
+- Re-throw errors from the hook so the caller can react (e.g. skip navigation)
+- Use `finally` to always reset `isPending`
+- Component calls the hook, navigates on success, and reads `error` for display
+
+```ts
+// ✅ correct
+const { changePassword, error, isPending } = useChangePassword();
+
+// ❌ wrong — apiFetch called directly in component
+await apiFetch("/auth/change-password", { ... });
+```
+
 ## MVP feature set
 
 -  Multi-tenant (organization), authenticate users and authorize then based on their roles

--- a/bun.lock
+++ b/bun.lock
@@ -16,11 +16,15 @@
     "client": {
       "name": "@mission/client",
       "dependencies": {
+        "@hookform/resolvers": "^5.2.2",
         "@mission/shared": "workspace:*",
+        "@tailwindcss/vite": "^4.2.1",
         "@tanstack/react-query": "^5.0.0",
         "better-auth": "^1.0.0",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
+        "react-hook-form": "^7.71.2",
+        "tailwindcss": "^4.2.1",
         "wouter": "^3.3.0",
         "zod": "^3.23.0",
         "zustand": "^5.0.0",
@@ -198,6 +202,8 @@
 
     "@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
 
+    "@hookform/resolvers": ["@hookform/resolvers@5.2.2", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "react-hook-form": "^7.55.0" } }, "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA=="],
+
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
@@ -331,6 +337,38 @@
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
+
+    "@tailwindcss/node": ["@tailwindcss/node@4.2.1", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.31.1", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.1" } }, "sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg=="],
+
+    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.2.1", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.2.1", "@tailwindcss/oxide-darwin-arm64": "4.2.1", "@tailwindcss/oxide-darwin-x64": "4.2.1", "@tailwindcss/oxide-freebsd-x64": "4.2.1", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.1", "@tailwindcss/oxide-linux-arm64-gnu": "4.2.1", "@tailwindcss/oxide-linux-arm64-musl": "4.2.1", "@tailwindcss/oxide-linux-x64-gnu": "4.2.1", "@tailwindcss/oxide-linux-x64-musl": "4.2.1", "@tailwindcss/oxide-wasm32-wasi": "4.2.1", "@tailwindcss/oxide-win32-arm64-msvc": "4.2.1", "@tailwindcss/oxide-win32-x64-msvc": "4.2.1" } }, "sha512-yv9jeEFWnjKCI6/T3Oq50yQEOqmpmpfzG1hcZsAOaXFQPfzWprWrlHSdGPEF3WQTi8zu8ohC9Mh9J470nT5pUw=="],
+
+    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.2.1", "", { "os": "android", "cpu": "arm64" }, "sha512-eZ7G1Zm5EC8OOKaesIKuw77jw++QJ2lL9N+dDpdQiAB/c/B2wDh0QPFHbkBVrXnwNugvrbJFk1gK2SsVjwWReg=="],
+
+    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.2.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-q/LHkOstoJ7pI1J0q6djesLzRvQSIfEto148ppAd+BVQK0JYjQIFSK3JgYZJa+Yzi0DDa52ZsQx2rqytBnf8Hw=="],
+
+    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.2.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-/f/ozlaXGY6QLbpvd/kFTro2l18f7dHKpB+ieXz+Cijl4Mt9AI2rTrpq7V+t04nK+j9XBQHnSMdeQRhbGyt6fw=="],
+
+    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.2.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-5e/AkgYJT/cpbkys/OU2Ei2jdETCLlifwm7ogMC7/hksI2fC3iiq6OcXwjibcIjPung0kRtR3TxEITkqgn0TcA=="],
+
+    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.2.1", "", { "os": "linux", "cpu": "arm" }, "sha512-Uny1EcVTTmerCKt/1ZuKTkb0x8ZaiuYucg2/kImO5A5Y/kBz41/+j0gxUZl+hTF3xkWpDmHX+TaWhOtba2Fyuw=="],
+
+    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-CTrwomI+c7n6aSSQlsPL0roRiNMDQ/YzMD9EjcR+H4f0I1SQ8QqIuPnsVp7QgMkC1Qi8rtkekLkOFjo7OlEFRQ=="],
+
+    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ=="],
+
+    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g=="],
+
+    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g=="],
+
+    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.2.1", "", { "dependencies": { "@emnapi/core": "^1.8.1", "@emnapi/runtime": "^1.8.1", "@emnapi/wasi-threads": "^1.1.0", "@napi-rs/wasm-runtime": "^1.1.1", "@tybys/wasm-util": "^0.10.1", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q=="],
+
+    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.2.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-YlUEHRHBGnCMh4Nj4GnqQyBtsshUPdiNroZj8VPkvTZSoHsilRCwXcVKnG9kyi0ZFAS/3u+qKHBdDc81SADTRA=="],
+
+    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.2.1", "", { "os": "win32", "cpu": "x64" }, "sha512-rbO34G5sMWWyrN/idLeVxAZgAKWrn5LiR3/I90Q9MkA67s6T1oB0xtTe+0heoBvHSpbU9Mk7i6uwJnpo4u21XQ=="],
+
+    "@tailwindcss/vite": ["@tailwindcss/vite@4.2.1", "", { "dependencies": { "@tailwindcss/node": "4.2.1", "@tailwindcss/oxide": "4.2.1", "tailwindcss": "4.2.1" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7" } }, "sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w=="],
 
     "@tanstack/query-core": ["@tanstack/query-core@5.90.20", "", {}, "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg=="],
 
@@ -540,6 +578,8 @@
 
     "destroy": ["destroy@1.2.0", "", {}, "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="],
 
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
     "dns-zonefile": ["dns-zonefile@0.1.18", "", { "bin": { "zonefile": "./bin/zonefile" } }, "sha512-0G25rYPwTCMT3DjN+UTpHUpUxsUjfIH+24H7O0XgfSRtxQc01UNAvo2zWzuzq3qHTVxgTdSllkUmHFZ/+UDkYA=="],
 
     "dot-prop": ["dot-prop@2.4.0", "", { "dependencies": { "is-obj": "^1.0.0" } }, "sha512-wAg7VK6GV/tLH/Lkuqt/uMn6hUDJpWYt+0mAcaGL6nxlNZMbF+0nKu+HgfKVYGbGn/l8I4BzkCHA916OCFgdpg=="],
@@ -569,6 +609,8 @@
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
+    "enhanced-resolve": ["enhanced-resolve@5.20.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ=="],
 
     "ent": ["ent@2.2.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "punycode": "^1.4.1", "safe-regex-test": "^1.1.0" } }, "sha512-kKvD1tO6BM+oK9HzCPpUdRb4vKFQY/FPTFmurMvh6LlN68VMrdj77w8yp51/kDbpkFOS9J8w5W6zIzgM2H8/hw=="],
 
@@ -786,6 +828,30 @@
 
     "lcid": ["lcid@1.0.0", "", { "dependencies": { "invert-kv": "^1.0.0" } }, "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw=="],
 
+    "lightningcss": ["lightningcss@1.31.1", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.31.1", "lightningcss-darwin-arm64": "1.31.1", "lightningcss-darwin-x64": "1.31.1", "lightningcss-freebsd-x64": "1.31.1", "lightningcss-linux-arm-gnueabihf": "1.31.1", "lightningcss-linux-arm64-gnu": "1.31.1", "lightningcss-linux-arm64-musl": "1.31.1", "lightningcss-linux-x64-gnu": "1.31.1", "lightningcss-linux-x64-musl": "1.31.1", "lightningcss-win32-arm64-msvc": "1.31.1", "lightningcss-win32-x64-msvc": "1.31.1" } }, "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.31.1", "", { "os": "android", "cpu": "arm64" }, "sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.31.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.31.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.31.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.31.1", "", { "os": "linux", "cpu": "arm" }, "sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.31.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.31.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.31.1", "", { "os": "linux", "cpu": "x64" }, "sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.31.1", "", { "os": "linux", "cpu": "x64" }, "sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.31.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.31.1", "", { "os": "win32", "cpu": "x64" }, "sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw=="],
+
     "lilconfig": ["lilconfig@2.1.0", "", {}, "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ=="],
 
     "lodash": ["lodash@3.10.1", "", {}, "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ=="],
@@ -803,6 +869,8 @@
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "lru.min": ["lru.min@1.1.4", "", {}, "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "make-dir": ["make-dir@1.3.0", "", { "dependencies": { "pify": "^3.0.0" } }, "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ=="],
 
@@ -954,6 +1022,8 @@
 
     "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
 
+    "react-hook-form": ["react-hook-form@7.71.2", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA=="],
+
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 
     "read-all-stream": ["read-all-stream@3.1.0", "", { "dependencies": { "pinkie-promise": "^2.0.0", "readable-stream": "^2.0.0" } }, "sha512-DI1drPHbmBcUDWrJ7ull/F2Qb8HkwBncVx8/RpKYFSIACYaVRQReISYPdZz/mt1y1+qMCOrfReTopERmaxtP6w=="],
@@ -1059,6 +1129,10 @@
     "stubs": ["stubs@3.0.0", "", {}, "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw=="],
 
     "supports-color": ["supports-color@2.0.0", "", {}, "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g=="],
+
+    "tailwindcss": ["tailwindcss@4.2.1", "", {}, "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw=="],
+
+    "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
 
     "through": ["through@2.3.8", "", {}, "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="],
 
@@ -1169,6 +1243,18 @@
     "@prisma/fetch-engine/@prisma/get-platform": ["@prisma/get-platform@7.4.2", "", { "dependencies": { "@prisma/debug": "7.4.2" } }, "sha512-UTnChXRwiauzl/8wT4hhe7Xmixja9WE28oCnGpBtRejaHhvekx5kudr3R4Y9mLSA0kqGnAMeyTiKwDVMjaEVsw=="],
 
     "@prisma/get-platform/@prisma/debug": ["@prisma/debug@7.2.0", "", {}, "sha512-YSGTiSlBAVJPzX4ONZmMotL+ozJwQjRmZweQNIq/ER0tQJKJynNkRB3kyvt37eOfsbMCXk3gnLF6J9OJ4QWftw=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" }, "bundled": true }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "base64url/concat-stream": ["concat-stream@1.4.11", "", { "dependencies": { "inherits": "~2.0.1", "readable-stream": "~1.1.9", "typedarray": "~0.0.5" } }, "sha512-X3JMh8+4je3U1cQpG87+f9lXHDrqcb2MVLg9L7o8b1UZ0DzhRrUpdn65ttzu10PpJPPI3MQNkis+oha6TSA9Mw=="],
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,12 +2,18 @@
 
 import { Route, Switch } from "wouter";
 import { AuthGuard } from "./components/AuthGuard";
+import { ChangePasswordPage } from "./pages/ChangePasswordPage";
+import { LoginPage } from "./pages/LoginPage";
 
 export function App() {
   return (
     <Switch>
-      {/* TODO: add /login route (Feature 1) */}
-      {/* TODO: add /change-password route (Feature 1) */}
+      <Route path="/login" component={LoginPage} />
+      <Route path="/change-password">
+        <AuthGuard>
+          <ChangePasswordPage />
+        </AuthGuard>
+      </Route>
       <Route>
         <AuthGuard>
           {/* TODO: add authenticated routes (Feature 2+) */}

--- a/client/src/components/AuthGuard.tsx
+++ b/client/src/components/AuthGuard.tsx
@@ -17,7 +17,7 @@ export function AuthGuard({ children }: AuthGuardProps) {
   useEffect(() => {
     if (!isPending && !session) navigate("/login");
     else if (!isPending && user?.mustChangePassword) navigate("/change-password");
-  }, [session, isPending, user, navigate]);
+  }, [session, isPending, navigate]);
 
   if (isPending || !session) return null;
   return <>{children}</>;

--- a/client/src/components/AuthGuard.tsx
+++ b/client/src/components/AuthGuard.tsx
@@ -1,16 +1,24 @@
 // Redirects unauthenticated users to /login.
 // Redirects users with mustChangePassword=true to /change-password.
 
-import type { ReactNode } from "react";
-import { Redirect } from "wouter";
-import { authClient } from "../lib/auth";
+import { useEffect, type ReactNode } from "react";
+import { useLocation } from "wouter";
+import { authClient, type SessionUser } from "../lib/auth";
 
 interface AuthGuardProps {
   children: ReactNode;
 }
 
 export function AuthGuard({ children }: AuthGuardProps) {
-  // TODO: implement session check via authClient.useSession()
-  // Placeholder — always renders children until auth is wired up
+  const { data: session, isPending } = authClient.useSession();
+  const [, navigate] = useLocation();
+  const user = session?.user as SessionUser | undefined;
+
+  useEffect(() => {
+    if (!isPending && !session) navigate("/login");
+    else if (!isPending && user?.mustChangePassword) navigate("/change-password");
+  }, [session, isPending, user, navigate]);
+
+  if (isPending || !session) return null;
   return <>{children}</>;
 }

--- a/client/src/components/RoleGuard.tsx
+++ b/client/src/components/RoleGuard.tsx
@@ -2,9 +2,9 @@
 // Renders null otherwise (or an optional fallback).
 
 import type { ReactNode } from "react";
-import type { User } from "../../../shared/schema/auth";
+import { authClient, type SessionUser } from "../lib/auth";
 
-type Role = NonNullable<User["role"]>;
+type Role = SessionUser["role"];
 
 interface RoleGuardProps {
   roles: Role[];
@@ -12,7 +12,9 @@ interface RoleGuardProps {
   fallback?: ReactNode;
 }
 
-export function RoleGuard({ children, fallback = null }: RoleGuardProps) {
-  // TODO: implement role check via authClient.useSession()
-  return <>{children ?? fallback}</>;
+export function RoleGuard({ roles, children, fallback = null }: RoleGuardProps) {
+  const { data: session } = authClient.useSession();
+  const role = (session?.user as SessionUser | undefined)?.role;
+  if (!role || !roles.includes(role)) return <>{fallback}</>;
+  return <>{children}</>;
 }

--- a/client/src/hooks/useChangePassword.ts
+++ b/client/src/hooks/useChangePassword.ts
@@ -1,0 +1,31 @@
+import { useState } from "react";
+import { apiFetch } from "../lib/api";
+
+interface UseChangePasswordResult {
+  changePassword: (newPassword: string) => Promise<void>;
+  error: string | null;
+  isPending: boolean;
+}
+
+export function useChangePassword(): UseChangePasswordResult {
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, setIsPending] = useState(false);
+
+  async function changePassword(newPassword: string): Promise<void> {
+    setError(null);
+    setIsPending(true);
+    try {
+      await apiFetch("/auth/change-password", {
+        method: "POST",
+        body: JSON.stringify({ newPassword }),
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to change password");
+      throw err;
+    } finally {
+      setIsPending(false);
+    }
+  }
+
+  return { changePassword, error, isPending };
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -5,3 +5,17 @@ import { createAuthClient } from "better-auth/react";
 export const authClient = createAuthClient({
   baseURL: import.meta.env.VITE_API_URL as string,
 });
+
+// Session user type that includes additionalFields configured in server/lib/auth.ts
+export type SessionUser = {
+  id: string;
+  email: string;
+  name: string;
+  emailVerified: boolean;
+  image?: string | null | undefined;
+  orgId: string;
+  role: "director" | "mission_lead" | "crew_member";
+  mustChangePassword: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+};

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,3 +1,4 @@
+import "./index.css";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";

--- a/client/src/pages/ChangePasswordPage.tsx
+++ b/client/src/pages/ChangePasswordPage.tsx
@@ -1,29 +1,25 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useLocation } from "wouter";
 import { ChangePasswordSchema, type ChangePasswordInput } from "../../../shared/contracts";
-import { apiFetch } from "../lib/api";
+import { useChangePassword } from "../hooks/useChangePassword";
+
 export function ChangePasswordPage() {
   const [, navigate] = useLocation();
-  const [error, setError] = useState<string | null>(null);
+  const { changePassword, error, isPending } = useChangePassword();
 
   const {
     register,
     handleSubmit,
-    formState: { errors, isSubmitting },
+    formState: { errors },
   } = useForm<ChangePasswordInput>({ resolver: zodResolver(ChangePasswordSchema) });
 
   async function onSubmit(data: ChangePasswordInput) {
-    setError(null);
     try {
-      await apiFetch("/auth/change-password", {
-        method: "POST",
-        body: JSON.stringify({ newPassword: data.newPassword }),
-      });
+      await changePassword(data.newPassword);
       navigate("/");
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to change password");
+    } catch {
+      // error state is set by the hook
     }
   }
 
@@ -52,10 +48,10 @@ export function ChangePasswordPage() {
           {error && <p role="alert" className="text-sm text-red-600">{error}</p>}
           <button
             type="submit"
-            disabled={isSubmitting}
+            disabled={isPending}
             className="w-full bg-blue-600 text-white rounded px-4 py-2 text-sm font-medium hover:bg-blue-700 disabled:opacity-50"
           >
-            {isSubmitting ? "Saving…" : "Set password"}
+            {isPending ? "Saving…" : "Set password"}
           </button>
         </form>
       </div>

--- a/client/src/pages/ChangePasswordPage.tsx
+++ b/client/src/pages/ChangePasswordPage.tsx
@@ -1,8 +1,17 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { useLocation } from "wouter";
-import { ChangePasswordSchema, type ChangePasswordInput } from "../../../shared/contracts";
+import { z } from "zod";
+import { ChangePasswordSchema } from "../../../shared/contracts";
 import { useChangePassword } from "../hooks/useChangePassword";
+
+const FormSchema = ChangePasswordSchema.extend({
+  confirmPassword: z.string(),
+}).refine((d) => d.newPassword === d.confirmPassword, {
+  message: "Passwords do not match",
+  path: ["confirmPassword"],
+});
+type FormInput = z.infer<typeof FormSchema>;
 
 export function ChangePasswordPage() {
   const [, navigate] = useLocation();
@@ -12,9 +21,9 @@ export function ChangePasswordPage() {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<ChangePasswordInput>({ resolver: zodResolver(ChangePasswordSchema) });
+  } = useForm<FormInput>({ resolver: zodResolver(FormSchema) });
 
-  async function onSubmit(data: ChangePasswordInput) {
+  async function onSubmit(data: FormInput) {
     try {
       await changePassword(data.newPassword);
       navigate("/");
@@ -43,6 +52,20 @@ export function ChangePasswordPage() {
             />
             {errors.newPassword && (
               <p className="mt-1 text-xs text-red-600">{errors.newPassword.message}</p>
+            )}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Confirm password
+            </label>
+            <input
+              {...register("confirmPassword")}
+              type="password"
+              autoComplete="new-password"
+              className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            {errors.confirmPassword && (
+              <p className="mt-1 text-xs text-red-600">{errors.confirmPassword.message}</p>
             )}
           </div>
           {error && <p role="alert" className="text-sm text-red-600">{error}</p>}

--- a/client/src/pages/ChangePasswordPage.tsx
+++ b/client/src/pages/ChangePasswordPage.tsx
@@ -4,8 +4,6 @@ import { useForm } from "react-hook-form";
 import { useLocation } from "wouter";
 import { ChangePasswordSchema, type ChangePasswordInput } from "../../../shared/contracts";
 import { apiFetch } from "../lib/api";
-import { authClient } from "../lib/auth";
-
 export function ChangePasswordPage() {
   const [, navigate] = useLocation();
   const [error, setError] = useState<string | null>(null);
@@ -23,7 +21,6 @@ export function ChangePasswordPage() {
         method: "POST",
         body: JSON.stringify({ newPassword: data.newPassword }),
       });
-      await authClient.getSession();
       navigate("/");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to change password");
@@ -52,7 +49,7 @@ export function ChangePasswordPage() {
               <p className="mt-1 text-xs text-red-600">{errors.newPassword.message}</p>
             )}
           </div>
-          {error && <p className="text-sm text-red-600">{error}</p>}
+          {error && <p role="alert" className="text-sm text-red-600">{error}</p>}
           <button
             type="submit"
             disabled={isSubmitting}

--- a/client/src/pages/ChangePasswordPage.tsx
+++ b/client/src/pages/ChangePasswordPage.tsx
@@ -1,0 +1,67 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { useLocation } from "wouter";
+import { ChangePasswordSchema, type ChangePasswordInput } from "../../../shared/contracts";
+import { apiFetch } from "../lib/api";
+import { authClient } from "../lib/auth";
+
+export function ChangePasswordPage() {
+  const [, navigate] = useLocation();
+  const [error, setError] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<ChangePasswordInput>({ resolver: zodResolver(ChangePasswordSchema) });
+
+  async function onSubmit(data: ChangePasswordInput) {
+    setError(null);
+    try {
+      await apiFetch("/auth/change-password", {
+        method: "POST",
+        body: JSON.stringify({ newPassword: data.newPassword }),
+      });
+      await authClient.getSession();
+      navigate("/");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to change password");
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="w-full max-w-sm bg-white rounded-lg shadow p-8">
+        <h1 className="text-xl font-semibold text-gray-900 mb-2">Set a new password</h1>
+        <p className="text-sm text-gray-500 mb-6">
+          You must set a new password before continuing.
+        </p>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              New password
+            </label>
+            <input
+              {...register("newPassword")}
+              type="password"
+              autoComplete="new-password"
+              className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            {errors.newPassword && (
+              <p className="mt-1 text-xs text-red-600">{errors.newPassword.message}</p>
+            )}
+          </div>
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full bg-blue-600 text-white rounded px-4 py-2 text-sm font-medium hover:bg-blue-700 disabled:opacity-50"
+          >
+            {isSubmitting ? "Saving…" : "Set password"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -29,7 +29,7 @@ export function LoginPage() {
       callbackURL: "/",
     });
     if (result.error) {
-      setError(result.error.message ?? "Sign in failed");
+      setError("Invalid email or password");
     } else {
       navigate("/");
     }

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -36,44 +36,125 @@ export function LoginPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
-      <div className="w-full max-w-sm bg-white rounded-lg shadow p-8">
-        <h1 className="text-2xl font-semibold text-gray-900 mb-6">Mission Control</h1>
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
-            <input
-              {...register("email")}
-              type="email"
-              autoComplete="email"
-              className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-            />
-            {errors.email && (
-              <p className="mt-1 text-xs text-red-600">{errors.email.message}</p>
-            )}
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Password</label>
-            <input
-              {...register("password")}
-              type="password"
-              autoComplete="current-password"
-              className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-            />
-            {errors.password && (
-              <p className="mt-1 text-xs text-red-600">{errors.password.message}</p>
-            )}
-          </div>
-          {error && <p className="text-sm text-red-600">{error}</p>}
-          <button
-            type="submit"
-            disabled={isSubmitting}
-            className="w-full bg-blue-600 text-white rounded px-4 py-2 text-sm font-medium hover:bg-blue-700 disabled:opacity-50"
-          >
-            {isSubmitting ? "Signing in…" : "Sign in"}
-          </button>
-        </form>
+    <div className="min-h-screen flex flex-col sm:flex-row">
+      {/* Left panel — brand & value prop (hidden on small screens) */}
+      <div className="hidden sm:flex sm:w-1/2 flex-col justify-between bg-gray-950 px-12 py-16">
+        <LogoMark />
+        <div>
+          <h1 className="text-4xl font-bold tracking-tight text-white leading-tight mb-4">
+            The right crew,<br />
+            <span className="bg-gradient-to-r from-blue-400 to-cyan-400 bg-clip-text text-transparent">
+              on every mission.
+            </span>
+          </h1>
+          <p className="text-gray-400 text-lg leading-relaxed max-w-sm">
+            Multi-org crew management that eliminates manual cross-referencing.
+            Skill matching, availability tracking, and auto-assignment — in one place.
+          </p>
+        </div>
+        <TrustBadges />
       </div>
+
+      {/* Right panel — sign-in form */}
+      <div className="flex flex-1 flex-col items-center justify-center bg-white px-6 py-12 sm:px-12">
+        {/* Mobile-only logo */}
+        <div className="mb-8 sm:hidden">
+          <LogoMark dark={false} />
+        </div>
+
+        <div className="w-full max-w-sm">
+          <div className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900">Sign in to your org</h2>
+            <p className="mt-1 text-sm text-gray-500">
+              Enter your credentials to access Mission Control.
+            </p>
+          </div>
+
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Work email
+              </label>
+              <input
+                {...register("email")}
+                type="email"
+                autoComplete="email"
+                placeholder="you@yourorg.space"
+                className="w-full border border-gray-300 rounded-lg px-3 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
+              />
+              {errors.email && (
+                <p className="mt-1 text-xs text-red-600">{errors.email.message}</p>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Password
+              </label>
+              <input
+                {...register("password")}
+                type="password"
+                autoComplete="current-password"
+                className="w-full border border-gray-300 rounded-lg px-3 py-2.5 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
+              />
+              {errors.password && (
+                <p className="mt-1 text-xs text-red-600">{errors.password.message}</p>
+              )}
+            </div>
+
+            {error && (
+              <p role="alert" className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+                {error}
+              </p>
+            )}
+
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="w-full bg-blue-600 text-white rounded-lg px-4 py-2.5 text-sm font-medium hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 transition"
+            >
+              {isSubmitting ? "Signing in…" : "Sign in to Mission Control →"}
+            </button>
+          </form>
+
+          {/* Mobile trust signals */}
+          <div className="mt-6 sm:hidden">
+            <TrustBadges dark={false} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function LogoMark({ dark = true }: { dark?: boolean }) {
+  const textColor = dark ? "text-white" : "text-gray-900";
+  const subColor = dark ? "text-gray-400" : "text-gray-500";
+  return (
+    <div className="flex items-center gap-3">
+      <svg width="32" height="32" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+        <circle cx="16" cy="16" r="15" stroke={dark ? "#3b82f6" : "#2563eb"} strokeWidth="2" />
+        <circle cx="16" cy="16" r="6" fill={dark ? "#3b82f6" : "#2563eb"} />
+        <ellipse cx="16" cy="16" rx="15" ry="6" stroke={dark ? "#60a5fa" : "#3b82f6"} strokeWidth="1.5" strokeDasharray="3 2" />
+      </svg>
+      <div>
+        <span className={`text-base font-semibold ${textColor}`}>Mission Control</span>
+        <span className={`block text-xs ${subColor}`}>Crew Operations Platform</span>
+      </div>
+    </div>
+  );
+}
+
+function TrustBadges({ dark = true }: { dark?: boolean }) {
+  const color = dark ? "text-gray-500" : "text-gray-400";
+  const divider = dark ? "bg-gray-700" : "bg-gray-200";
+  return (
+    <div className={`flex items-center gap-3 text-xs ${color}`}>
+      <span>End-to-end encrypted</span>
+      <span className={`h-3 w-px ${divider}`} />
+      <span>Multi-org isolated</span>
+      <span className={`h-3 w-px ${divider}`} />
+      <span>Role-gated access</span>
     </div>
   );
 }

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -1,0 +1,79 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { useLocation } from "wouter";
+import { z } from "zod";
+import { authClient } from "../lib/auth";
+
+const LoginSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1),
+});
+type LoginInput = z.infer<typeof LoginSchema>;
+
+export function LoginPage() {
+  const [, navigate] = useLocation();
+  const [error, setError] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<LoginInput>({ resolver: zodResolver(LoginSchema) });
+
+  async function onSubmit(data: LoginInput) {
+    setError(null);
+    const result = await authClient.signIn.email({
+      email: data.email,
+      password: data.password,
+      callbackURL: "/",
+    });
+    if (result.error) {
+      setError(result.error.message ?? "Sign in failed");
+    } else {
+      navigate("/");
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="w-full max-w-sm bg-white rounded-lg shadow p-8">
+        <h1 className="text-2xl font-semibold text-gray-900 mb-6">Mission Control</h1>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
+            <input
+              {...register("email")}
+              type="email"
+              autoComplete="email"
+              className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            {errors.email && (
+              <p className="mt-1 text-xs text-red-600">{errors.email.message}</p>
+            )}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Password</label>
+            <input
+              {...register("password")}
+              type="password"
+              autoComplete="current-password"
+              className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            {errors.password && (
+              <p className="mt-1 text-xs text-red-600">{errors.password.message}</p>
+            )}
+          </div>
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full bg-blue-600 text-white rounded px-4 py-2 text-sm font-medium hover:bg-blue-700 disabled:opacity-50"
+          >
+            {isSubmitting ? "Signing in…" : "Sign in"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,8 +1,9 @@
+import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tailwindcss()],
   server: {
     port: 5173,
     proxy: {

--- a/server/middleware/requireAuth.ts
+++ b/server/middleware/requireAuth.ts
@@ -3,15 +3,14 @@
 // Returns 403 if mustChangePassword=true and route is not /auth/change-password.
 
 import type { NextFunction, Request, Response } from "express";
-import type { User } from "../../shared/schema/auth";
 import { AppError } from "../lib/errors";
-import { auth } from "../lib/auth";
+import { auth, type SessionUser } from "../lib/auth";
 
 // Extend Express Request with the authenticated user
 declare global {
   namespace Express {
     interface Request {
-      identity?: User;
+      identity?: SessionUser;
     }
   }
 }
@@ -21,6 +20,13 @@ export async function requireAuth(
   res: Response,
   next: NextFunction,
 ): Promise<void> {
-  // TODO: implement session validation via auth.api.getSession
-  next(new AppError(401, "Unauthorized"));
+  const session = await auth.api.getSession({ headers: req.headers as unknown as Headers });
+  if (!session) {
+    return next(new AppError(401, "Unauthorized"));
+  }
+  if (session.user.mustChangePassword && req.path !== "/auth/change-password") {
+    return next(new AppError(403, "PASSWORD_CHANGE_REQUIRED"));
+  }
+  req.identity = session.user;
+  next();
 }

--- a/server/middleware/requireRole.ts
+++ b/server/middleware/requireRole.ts
@@ -9,7 +9,7 @@ type Role = NonNullable<User["role"]>;
 
 export function requireRole(...roles: Role[]) {
   return (req: Request, _res: Response, next: NextFunction): void => {
-    const role = req.identity?.role;
+    const role = req.identity?.role as Role | undefined;
     if (!role || !roles.includes(role)) {
       next(new AppError(403, "Forbidden"));
       return;

--- a/server/routes/admin/invite.ts
+++ b/server/routes/admin/invite.ts
@@ -1,7 +1,13 @@
 // POST /api/admin/invite — director invites a new user with a temp password.
 // better-auth is bypassed here; we hash the password with argon2 and insert directly.
 
+import { hash } from "@node-rs/argon2";
+import { eq } from "drizzle-orm";
 import { Router } from "express";
+import { accounts, users } from "../../../shared/schema/auth";
+import { InviteUserSchema } from "../../../shared/contracts";
+import { db } from "../../lib/db";
+import { AppError } from "../../lib/errors";
 import { requireAuth } from "../../middleware/requireAuth";
 import { requireRole } from "../../middleware/requireRole";
 
@@ -11,8 +17,42 @@ inviteRouter.post(
   "/invite",
   requireAuth,
   requireRole("director"),
-  async (_req, res) => {
-    // TODO: implement invite flow (validate body, hash temp password, insert user)
-    res.status(501).json({ error: "Not implemented" });
+  async (req, res, next) => {
+    const result = InviteUserSchema.safeParse(req.body);
+    if (!result.success) return next(new AppError(400, "Invalid request"));
+
+    const { email, name, role, temporaryPassword } = result.data;
+    const orgId = req.identity!.orgId;
+
+    const existing = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.email, email))
+      .limit(1);
+    if (existing.length > 0) return next(new AppError(400, "Email already in use"));
+
+    const passwordHash = await hash(temporaryPassword);
+    const userId = crypto.randomUUID();
+
+    await db.transaction(async (tx) => {
+      await tx.insert(users).values({
+        id: userId,
+        email,
+        name,
+        emailVerified: true,
+        orgId,
+        role,
+        mustChangePassword: true,
+      });
+      await tx.insert(accounts).values({
+        id: crypto.randomUUID(),
+        accountId: email,
+        providerId: "credential",
+        userId,
+        password: passwordHash,
+      });
+    });
+
+    res.status(201).json({ success: true });
   },
 );

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -1,13 +1,43 @@
 // Auth routes — delegates to better-auth handler.
 // better-auth handles /sign-in, /sign-out, /get-session internally.
+// Custom POST /change-password is defined first (bypasses mustChangePassword guard).
 
+import { hash } from "@node-rs/argon2";
+import { toNodeHandler } from "better-auth/node";
+import { eq } from "drizzle-orm";
 import { Router } from "express";
+import { accounts, users } from "../../shared/schema/auth";
+import { ChangePasswordSchema } from "../../shared/contracts";
 import { auth } from "../lib/auth";
+import { db } from "../lib/db";
+import { AppError } from "../lib/errors";
+import { requireAuth } from "../middleware/requireAuth";
 
 export const authRouter = Router();
 
-// Delegate all /api/auth/* requests to better-auth
-authRouter.all("/*", async (req, res) => {
-  // TODO: implement better-auth request handler integration
-  res.status(501).json({ error: "Not implemented" });
+// Custom forced change-password — accessible even when mustChangePassword=true
+authRouter.post("/change-password", requireAuth, async (req, res, next) => {
+  const result = ChangePasswordSchema.safeParse(req.body);
+  if (!result.success) {
+    return next(new AppError(400, "Invalid request"));
+  }
+  const { newPassword } = result.data;
+  const userId = req.identity!.id;
+
+  const passwordHash = await hash(newPassword);
+
+  await db
+    .update(accounts)
+    .set({ password: passwordHash })
+    .where(eq(accounts.userId, userId));
+
+  await db
+    .update(users)
+    .set({ mustChangePassword: false })
+    .where(eq(users.id, userId));
+
+  res.json({ success: true });
 });
+
+// Delegate all other /api/auth/* to better-auth
+authRouter.all("/*splat", toNodeHandler(auth));

--- a/shared/contracts.ts
+++ b/shared/contracts.ts
@@ -7,9 +7,15 @@ export const InviteUserSchema = z.object({
   name: z.string().min(1),
   email: z.string().email(),
   role: z.enum(["mission_lead", "crew_member"]), // directors cannot be invited
+  temporaryPassword: z.string().min(8),
 });
 
 export type InviteUserInput = z.infer<typeof InviteUserSchema>;
+
+export const ChangePasswordSchema = z.object({
+  newPassword: z.string().min(8),
+});
+export type ChangePasswordInput = z.infer<typeof ChangePasswordSchema>;
 
 // TODO: CreateMissionSchema — Feature 2
 // TODO: UpdateProfileSchema — Feature 3


### PR DESCRIPTION
## Summary

- **Session middleware**: `requireAuth` validates sessions via `auth.api.getSession`, enforces `mustChangePassword` gate, attaches `req.identity` as `SessionUser`
- **Auth routes**: wired `toNodeHandler(auth)` catch-all for better-auth; custom `POST /auth/change-password` updates argon2 hash and clears `mustChangePassword` flag
- **Invite endpoint**: `POST /admin/invite` bypasses better-auth — hashes temp password with argon2 and inserts user + account in a DB transaction
- **Frontend**: `LoginPage` and `ChangePasswordPage` with react-hook-form + zod; `AuthGuard` redirects unauthenticated/mustChangePassword users; `RoleGuard` gates by role; Tailwind v4 added via `@tailwindcss/vite`

## Test plan

- [ ] `bun db:migrate && bun db:seed` then `bun run dev`
- [ ] Visit `/login`, sign in as `director@orion.space` / `Director@Orion1` → redirected to `/`
- [ ] Request with no session → 401
- [ ] Mission lead hitting director-only route → 403
- [ ] Invite a user, sign in → redirected to `/change-password`, submit new password → redirected to `/`
- [ ] Cross-org resource fetch → 404
- [ ] `bun run typecheck` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)